### PR TITLE
Implemented BatteryChargeStatus usage instead of "curbat" (last batte…

### DIFF
--- a/Battery Indicator/Form1.Designer.vb
+++ b/Battery Indicator/Form1.Designer.vb
@@ -30,6 +30,7 @@ Partial Class Form1
         Me.ExitToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.BatteryStatusToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.Timer2 = New System.Windows.Forms.Timer(Me.components)
+        Me.ChargingStatusToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ContextMenuStrip1.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -45,32 +46,38 @@ Partial Class Form1
         'ContextMenuStrip1
         '
         Me.ContextMenuStrip1.ImageScalingSize = New System.Drawing.Size(20, 20)
-        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ExitToolStripMenuItem, Me.BatteryStatusToolStripMenuItem})
+        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ExitToolStripMenuItem, Me.BatteryStatusToolStripMenuItem, Me.ChargingStatusToolStripMenuItem})
         Me.ContextMenuStrip1.Name = "ContextMenuStrip1"
-        Me.ContextMenuStrip1.Size = New System.Drawing.Size(170, 52)
+        Me.ContextMenuStrip1.Size = New System.Drawing.Size(211, 104)
         '
         'ExitToolStripMenuItem
         '
         Me.ExitToolStripMenuItem.Name = "ExitToolStripMenuItem"
-        Me.ExitToolStripMenuItem.Size = New System.Drawing.Size(169, 24)
+        Me.ExitToolStripMenuItem.Size = New System.Drawing.Size(210, 24)
         Me.ExitToolStripMenuItem.Text = "Exit"
         '
         'BatteryStatusToolStripMenuItem
         '
         Me.BatteryStatusToolStripMenuItem.Name = "BatteryStatusToolStripMenuItem"
-        Me.BatteryStatusToolStripMenuItem.Size = New System.Drawing.Size(169, 24)
+        Me.BatteryStatusToolStripMenuItem.Size = New System.Drawing.Size(210, 24)
         Me.BatteryStatusToolStripMenuItem.Text = "Battery Status"
         '
         'Timer2
         '
         Me.Timer2.Interval = 60000
         '
+        'ChargingStatusToolStripMenuItem
+        '
+        Me.ChargingStatusToolStripMenuItem.Name = "ChargingStatusToolStripMenuItem"
+        Me.ChargingStatusToolStripMenuItem.Size = New System.Drawing.Size(210, 24)
+        Me.ChargingStatusToolStripMenuItem.Text = "Charging Status"
+        '
         'Form1
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 16.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(379, 321)
-        Me.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.Margin = New System.Windows.Forms.Padding(4)
         Me.Name = "Form1"
         Me.Text = "Form1"
         Me.ContextMenuStrip1.ResumeLayout(False)
@@ -83,4 +90,5 @@ Partial Class Form1
     Friend WithEvents ExitToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem
     Friend WithEvents BatteryStatusToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem
     Friend WithEvents Timer2 As Timer
+    Friend WithEvents ChargingStatusToolStripMenuItem As ToolStripMenuItem
 End Class

--- a/Battery Indicator/Form1.vb
+++ b/Battery Indicator/Form1.vb
@@ -1,13 +1,11 @@
 ﻿Public Class Form1
 
-    Dim curbat As Double = 0
     Dim relax As Boolean = False
 
     Private Sub Form1_Load(sender As System.Object, e As System.EventArgs) Handles MyBase.Load
 
         Dim power As PowerStatus = SystemInformation.PowerStatus
         Dim percent As Single = power.BatteryLifePercent
-        curbat = -1
         Timer1.Enabled = True
         NotifyIcon1.Visible = True
 
@@ -15,28 +13,27 @@
 
     Private Sub Timer1_Tick(sender As System.Object, e As System.EventArgs) Handles Timer1.Tick
 
-        Hide()
+        Hide()  'stay hidden
 
         Dim power As PowerStatus = SystemInformation.PowerStatus
         Dim percent As Single = power.BatteryLifePercent
+        Dim charge As Single = power.BatteryChargeStatus
 
-        If Not curbat = percent And Not relax Then
+        If Not relax Then                                               'enough time after last notify has passed
 
-            If percent >= 0.8 And percent > curbat Then
+            If percent >= 0.8 And Math.Abs(charge - 8) < 2 Then         'battery over 80% and charging (using status 7,8 and 9 as charging???)
 
                 Timer2.Enabled = True
                 relax = True
-                curbat = percent
                 NotifyIcon1.BalloonTipIcon = ToolTipIcon.Warning
                 NotifyIcon1.BalloonTipTitle = "Battery Indicator"
                 NotifyIcon1.BalloonTipText = "Battery over 80%"
                 NotifyIcon1.ShowBalloonTip(5000)
 
-            ElseIf percent <= 0.3 And percent < curbat Then
+            ElseIf percent <= 0.3 And Math.Abs(charge - 8) >= 2 Then    'battery under 30% and discharging
 
                 Timer2.Enabled = True
                 relax = True
-                curbat = percent
                 NotifyIcon1.BalloonTipIcon = ToolTipIcon.Warning
                 NotifyIcon1.BalloonTipTitle = "Battery Indicator"
                 NotifyIcon1.BalloonTipText = "Battery under 30%"
@@ -45,6 +42,13 @@
             End If
 
         End If
+
+    End Sub
+
+    Private Sub Timer2_Tick(sender As Object, e As EventArgs) Handles Timer2.Tick
+
+        Timer2.Enabled = False
+        relax = False
 
     End Sub
 
@@ -69,10 +73,16 @@
 
     End Sub
 
-    Private Sub Timer2_Tick(sender As Object, e As EventArgs) Handles Timer2.Tick
+    Private Sub ChargingStatusToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ChargingStatusToolStripMenuItem.Click
 
-        Timer2.Enabled = False
-        relax = False
+        Dim power As PowerStatus = SystemInformation.PowerStatus
+        Dim charge As Single = power.BatteryChargeStatus
+
+        If Math.Abs(charge - 8) < 2 Then    'really have no idea why this returns 9 instead of 8
+            MsgBox("Battery charging")
+        Else
+            MsgBox("Battery discharging")
+        End If
 
     End Sub
 End Class


### PR DESCRIPTION
…ry vs current)

BatteryChargeStatus is not returning 8 while charging, so a margin was given (7,8 and 9 are interpreted as charging)